### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@ dotfiles
 
 my dotfiles
 
-##usage
+## usage
 1. git clone git@github.com:notice501/dotfiles.git
 2. link all the files you need, like this:ln -s ~/dotfiles/vim/vimrc ~/.vimrc
 
-##vim configuration
-####1.link vim files
+## vim configuration
+#### 1.link vim files
 ```
 ln -s ~/dotfiles/vim/vimrc ~/.vimrc
 ln -s ~/dotfiles/vim/ ~/.vim
 ```
-####2.intall plugins
+#### 2.intall plugins
 I use [Vundle](https://github.com/VundleVim/Vundle.vim) to manager plugins, then you should install vundle first.
 
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
